### PR TITLE
Return string to allow string parsing

### DIFF
--- a/lib/scripts/dice.js
+++ b/lib/scripts/dice.js
@@ -15,7 +15,7 @@ module.exports = function(robot) {
     var m, n, _i, _results;
     m = res.match[1];
     n = res.match[2];
-    return res.send((function() {
+    return res.send('' + (function() {
       _results = [];
       for (var _i = 0; 0 <= m ? _i < m : _i > m; 0 <= m ? _i++ : _i--){ _results.push(_i); }
       return _results;


### PR DESCRIPTION
Hubot-Slack attempts to replace any @ notifications using String.replace. Returning a number breaks that functionality.

Changed to return a string
